### PR TITLE
pass match index to replace function in emojify.replace

### DIFF
--- a/src/emojify.js
+++ b/src/emojify.js
@@ -238,7 +238,7 @@
                         return replacer.apply({
                                 config: defaultConfig
                             },
-                            [arguments[0], emojiName]
+                            [arguments[0], emojiName, index]
                         );
                     }
                     /* Did not validate, return the original value */


### PR DESCRIPTION
I am working on a React component that wraps emojify.js.

Having access to the index of the match would save me a bit of work,
since I need to break up the string into React elements to replace the
emojis.

A more complete solution would return an array of match objects, similar
to linkify-it.  But this is a simple change that gets me 90% there.

Thanks!