### PR TITLE
fix elements blacklist

### DIFF
--- a/src/emojify.js
+++ b/src/emojify.js
@@ -96,7 +96,7 @@
                 blacklist: {
                     'ids': [],
                     'classes': ['no-emojify'],
-                    'elements': ['script', 'textarea', 'a', 'pre', 'code']
+                    'elements': ['^script$', '^textarea$', '^a$', '^pre$', '^code$']
                 },
                 tag_type: null,
                 only_crawl_id: null,


### PR DESCRIPTION
Emojify.js won't work when the emoji keywords were in the `<article>` element.
This can fix it.