### PR TITLE
Fixes #154: cannot render emoji inside a table

### DIFF
--- a/src/emojify.js
+++ b/src/emojify.js
@@ -306,7 +306,7 @@
 
                 var nodes = [];
 
-                var elementsBlacklist = new RegExp(defaultConfig.blacklist.elements.join('|'), 'i'),
+                var elementsBlacklist = new RegExp('^(' + defaultConfig.blacklist.elements.join('|') + ')$', 'i'),
                     classesBlacklist = new RegExp(defaultConfig.blacklist.classes.join('|'), 'i');
 
                 if(typeof win.document.createTreeWalker !== 'undefined') {
@@ -314,7 +314,7 @@
                         el,
                         win.NodeFilter.SHOW_TEXT | win.NodeFilter.SHOW_ELEMENT,
                         function(node) {
-                            if(node.nodeType !== 1) {
+                            if(node.nodeType === node.TEXT_NODE) {
                                 /* Text Node? Good! */
                                 return win.NodeFilter.FILTER_ACCEPT;
                             }

--- a/src/emojify.js
+++ b/src/emojify.js
@@ -342,7 +342,7 @@
                         ){
                             return false;
                         }
-                        if (node.nodeType === 1) {
+                        if (node.nodeType === node.TEXT_NODE) {
                             return true;
                         }
 


### PR DESCRIPTION
With the default black list, `node.tagName.match(elementsBlacklist)` returned `Array['A']` for a `table` element.
Now it returns `null`, the correct answer.

Another modification, I used the constant `node.TEXT_NODE` from [MDN](https://developer.mozilla.org/fr/docs/Web/API/Node/nodeType).